### PR TITLE
Add accordion to hold name search and tag filtering sections

### DIFF
--- a/view/src/components/produce.js
+++ b/view/src/components/produce.js
@@ -329,7 +329,7 @@ class Produce extends Component {
             <Typography className={classes.heading}>Filter by Tags</Typography>
           </AccordionSummary>
           <AccordionDetails>
-            {/* Skeleton to add tag filtering */}
+            {/* TODO(fatimazali): Add tag filtering) */}
             <Typography>Select tags to filter by:</Typography>
           </AccordionDetails>
         </Accordion>

--- a/view/src/components/produce.js
+++ b/view/src/components/produce.js
@@ -28,6 +28,10 @@ import axios from "axios";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { authMiddleWare } from "../util/auth";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 const styles = (theme) => ({
   content: {
@@ -68,7 +72,7 @@ const styles = (theme) => ({
     margin: "0 2px",
     transform: "scale(0.8)",
   },
-  pos: {
+  position: {
     marginBottom: 12,
   },
   uiProgress: {
@@ -273,6 +277,66 @@ class Produce extends Component {
     return this.state.value;
   };
 
+  filteringAccordion = () => {
+    const { classes } = this.props;
+    const { data, value } = this.state;
+
+    return (
+      <div>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography className={classes.heading}>Search by Name</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Autocomplete
+              id="produce-name-search"
+              options={data.map((produce) => produce.name)}
+              value={value}
+              onSelect={this.handleSearch} // Receive the name from data element for value
+              fullWidth={true}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Produce Names"
+                  variant="outlined"
+                  onChange={this.handleSearch}
+                  InputProps={{
+                    ...params.InputProps,
+                    startAdornment: (
+                      <>
+                        <InputAdornment position="start">
+                          <SearchIcon />
+                        </InputAdornment>
+                        {params.InputProps.startAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+            />
+          </AccordionDetails>
+        </Accordion>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel2a-content"
+            id="panel2a-header"
+          >
+            <Typography className={classes.heading}>Filter by Tags</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {/* Skeleton to add tag filtering */}
+            <Typography>Select tags to filter by:</Typography>
+          </AccordionDetails>
+        </Accordion>
+      </div>
+    );
+  };
+
   // Handles the rendering of filtered produce results into React cards
   handleResultsRender = (results) => {
     const { classes } = this.props;
@@ -294,7 +358,10 @@ class Produce extends Component {
                     margin={0}
                   >
                     <Box padding={3}>
-                      <Typography className={classes.pos} color="textSecondary">
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
                         Shipping Temperatures in Reefer (°F):
                       </Typography>
                       <Typography variant="body2" component="p">
@@ -306,7 +373,10 @@ class Produce extends Component {
                       </Typography>
                     </Box>
                     <Box padding={3}>
-                      <Typography className={classes.pos} color="textSecondary">
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
                         Pricing (in USD / lb):
                       </Typography>
                       <Typography variant="body2" component="p">
@@ -316,7 +386,10 @@ class Produce extends Component {
                       </Typography>
                     </Box>
                     <Box padding={3}>
-                      <Typography className={classes.pos} color="textSecondary">
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
                         Internal Statistics:
                       </Typography>
                       <Typography variant="body2" component="p">
@@ -670,32 +743,7 @@ class Produce extends Component {
           <Container maxWidth="lg">
             <Grid container spacing={2} alignItem="center">
               <Grid item xs={12}>
-                <Autocomplete
-                  id="produce-name-search"
-                  options={data.map((produce) => produce.name)}
-                  value={value}
-                  onSelect={this.handleSearch} // Receive the name from data element for value
-                  fullWidth={true}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label="Search by produce name"
-                      variant="outlined"
-                      onChange={this.handleSearch}
-                      InputProps={{
-                        ...params.InputProps,
-                        startAdornment: (
-                          <>
-                            <InputAdornment position="start">
-                              <SearchIcon />
-                            </InputAdornment>
-                            {params.InputProps.startAdornment}
-                          </>
-                        ),
-                      }}
-                    />
-                  )}
-                />
+                {this.filteringAccordion()}
               </Grid>
             </Grid>
             <SearchResults
@@ -723,7 +771,10 @@ class Produce extends Component {
                 margin={0}
               >
                 <Box padding={3}>
-                  <Typography className={classes.pos} color="textSecondary">
+                  <Typography
+                    className={classes.position}
+                    color="textSecondary"
+                  >
                     Shipping Temperatures in Reefer (°F):
                   </Typography>
                   <Typography variant="body2" component="p">
@@ -736,7 +787,10 @@ class Produce extends Component {
                   </Typography>
                 </Box>
                 <Box padding={3}>
-                  <Typography className={classes.pos} color="textSecondary">
+                  <Typography
+                    className={classes.position}
+                    color="textSecondary"
+                  >
                     Internal Statistics:
                   </Typography>
                   <Typography variant="body2" component="p">


### PR DESCRIPTION
Created an accordion to house all of the user's search and filtering options. For produce, this is simpler, but for farms/food banks, this will include location search and also Angeline's Maps API integration form. 

Input on the UI details are welcome -- should we make the header text a dark or medium grey instead? Or add some hierarchy with bold text?

I ran the file and made changes in the AddAccordion branch

![React App](https://user-images.githubusercontent.com/43034257/90864791-2ec37a00-e346-11ea-9f6d-7155e0fde858.gif)
