### PR TITLE
Add food bank multi-search: name, location, tags, distance

### DIFF
--- a/view/src/components/farms.js
+++ b/view/src/components/farms.js
@@ -291,6 +291,21 @@ class Farms extends Component {
     this.state.tagsQuery.map((item) => this.simpleSearch("tags-search", item));
   };
 
+  /** Combine all tags in filteredData items to update tags that user can select */
+  populateAllFarmTags = () => {
+    const { filteredData } = this.state;
+    var populatedTags = [];
+    filteredData.map((data) =>
+      populatedTags.push.apply(populatedTags, data.farmTags)
+    );
+    // Get unique tags only
+    const populatedUniqueTags = [...new Set(populatedTags)];
+
+    this.setState({
+      allFarmTags: populatedUniqueTags,
+    });
+  };
+
   /** Update tagQueries and search the cards by tags */
   handleTagFilter = (event, values) => {
     if (values.length === 0) {
@@ -518,6 +533,8 @@ class Farms extends Component {
     );
   };
 
+  /** End functions for sorting menu on top of the page */
+
   /** Renders filtered produce results into Material-UI cards */
   handleResultsRender = () => {
     const { classes } = this.props;
@@ -618,8 +635,6 @@ class Farms extends Component {
     );
   };
 
-  /** End functions for sorting menu on top of the page */
-
   /**
    * Given an event, this function updates a state (the target of the event)
    * with a new value
@@ -628,21 +643,6 @@ class Farms extends Component {
   handleChange = (event) => {
     this.setState({
       [event.target.name]: event.target.value,
-    });
-  };
-
-  /** Combine all tags in filteredData items to update tags that user can select */
-  populateAllFarmTags = () => {
-    const { filteredData } = this.state;
-    var populatedTags = [];
-    filteredData.map((data) =>
-      populatedTags.push.apply(populatedTags, data.farmTags)
-    );
-    // Get unique tags only
-    const populatedUniqueTags = [...new Set(populatedTags)];
-
-    this.setState({
-      allFarmTags: populatedUniqueTags,
     });
   };
 
@@ -700,6 +700,7 @@ class Farms extends Component {
       })
       .catch((err) => {
         console.error(err);
+        this.props.alert("error", "Error loading in the farms!");
       });
   }
 
@@ -956,6 +957,7 @@ class Farms extends Component {
                     <Address
                       handleLocation={this.handleLocation}
                       location={this.state.location}
+                      searching={false}
                     />
                   </Grid>
                   <Grid item xs={4}>

--- a/view/src/components/farms.js
+++ b/view/src/components/farms.js
@@ -521,7 +521,6 @@ class Farms extends Component {
 
   /** Reset filteredData to the original page data, upon clicking reset */
   resetCards = () => {
-    this.props.clearQueries();
     this.setState(
       {
         filteredData: [...this.state.data],

--- a/view/src/components/farms.js
+++ b/view/src/components/farms.js
@@ -275,15 +275,14 @@ class Farms extends Component {
     // queryName is used instead of event.target.name or event.target.id
     // since both onChange and onSelect call this function with id and name
     const { value } = event.target;
-    if (value === "") {
-      return;
+    if (value) {
+      this.setState(
+        {
+          [queryName]: value,
+        },
+        this.simpleSearch(queryName, value)
+      );
     }
-    this.setState(
-      {
-        [queryName]: value,
-      },
-      this.simpleSearch(queryName, value)
-    );
   };
 
   /** Search the cards by the current tagQueries. */

--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -70,7 +70,7 @@ class Filters extends Component {
   filterByDistance = () => {
     let url = "";
     switch (this.props.database) {
-      case "c":
+      case "foodbanks":
         url = "/queryFoodBanksByDistance";
         break;
       case "farms":

--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -70,7 +70,7 @@ class Filters extends Component {
   filterByDistance = () => {
     let url = "";
     switch (this.props.database) {
-      case "foodbanks":
+      case "c":
         url = "/queryFoodBanksByDistance";
         break;
       case "farms":

--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -141,7 +141,7 @@ class Filters extends Component {
             TextFieldLabel="Custom Location"
           />
         </Grid>
-        <Grid item xs={2}>
+        <Grid item xs={3}>
           <TextField
             variant="outlined"
             label="Distance (Miles)"
@@ -151,7 +151,7 @@ class Filters extends Component {
             onChange={this.handleChange}
           />
         </Grid>
-        <Grid item xs={10}>
+        <Grid item xs={3}>
           <Button
             className={styles.searchButton}
             onClick={this.filterByDistance}
@@ -193,7 +193,7 @@ class Filters extends Component {
             onChange={this.handleChange}
           />
         </Grid>
-        <Grid item xs={9}>
+        <Grid item xs={3}>
           <Button
             className={styles.searchButton}
             onClick={this.filterByTravelTime}

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -526,7 +526,6 @@ class Foodbank extends Component {
 
   /** Reset filteredData to the original page data, upon clicking reset */
   resetCards = () => {
-    this.props.clearQueries();
     this.setState(
       {
         filteredData: [...this.state.foodbanks],
@@ -1171,7 +1170,7 @@ class Foodbank extends Component {
                       id="foodbankTags"
                       onChange={this.onTagsChange}
                       options={unfilteredTags}
-                      defaultValue={[this.state.foodbankTags]}
+                      defaultValue={this.state.foodbankTags}
                       freeSolo
                       renderTags={(value, getTagProps) =>
                         value.map((option, index) => (

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import Address from "../extras/address_autocomplete_field";
 import CardSkeletons from "../extras/skeleton";
 import CustomTable from "../extras/table";
+import Filters from "./filters";
 
 import withStyles from "@material-ui/core/styles/withStyles";
 import Typography from "@material-ui/core/Typography";
@@ -35,16 +36,16 @@ import PropTypes from "prop-types";
 import MaskedInput from "react-text-mask";
 import Fab from "@material-ui/core/Fab";
 import AddIcon from "@material-ui/icons/Add";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import ClearIcon from "@material-ui/icons/Clear";
 
 import axios from "axios";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { authMiddleWare } from "../util/auth";
-
-const TAG_EXAMPLES = [
-  { title: "High Food Insecurity" },
-  { title: "Major City" },
-];
 
 const styles = (theme) => ({
   content: {
@@ -85,7 +86,7 @@ const styles = (theme) => ({
     margin: "0 2px",
     transform: "scale(0.8)",
   },
-  pos: {
+  position: {
     marginBottom: "12px",
   },
   dialogStyle: {
@@ -135,6 +136,21 @@ const styles = (theme) => ({
   },
   tablePadding: {
     marginTop: "24px",
+  },
+  clearSearchButton: {
+    position: "relative",
+  },
+  searchBars: {
+    marginTop: theme.spacing(3),
+  },
+  clearIcon: {
+    padding: theme.spacing(0, 2),
+    height: "100%",
+    position: "absolute",
+    pointerEvents: "none",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
   },
 });
 
@@ -202,8 +218,16 @@ class Foodbank extends Component {
     super(props);
 
     this.state = {
-      // food bank states
+      // Search states
       foodbanks: "",
+      filteredData: [],
+      nameQuery: "",
+      locationQuery: "",
+      tagsQuery: [],
+      allTags: [],
+      // Aggregated tags used for options when editing a specific item
+      unfilteredTags: [],
+      // Food bank states
       foodbankName: "",
       location: "",
       locationId: "",
@@ -216,12 +240,14 @@ class Foodbank extends Component {
       maxLoadSize: "",
       refrigerationSpaceAvailable: "",
       foodbankTags: [],
-      // page states
+      // Page states
       errors: [],
-      open: false, // used for opening food banks edit/create dialog (form)
+      open: false,
+      // Used for opening food banks edit/create dialog (form)
       uiLoading: true,
       buttonType: "",
-      viewOpen: false, // used for opening food banks view dialog
+      viewOpen: false,
+      // Used for opening food banks view dialog
       reloadCards: false,
       selectedCard: "",
     };
@@ -230,7 +256,425 @@ class Foodbank extends Component {
     this.handleDelete = this.handleDelete.bind(this);
     this.handleEditClick = this.handleEditClick.bind(this);
     this.handleViewOpen = this.handleViewOpen.bind(this);
+
+    this.handleStringSearch = this.handleStringSearch.bind(this);
+    this.simpleSearch = this.simpleSearch.bind(this);
+
+    this.populateAllFTags = this.populateAllTags.bind(this);
+    this.handleTagFilter = this.handleTagFilter.bind(this);
+    this.searchTagQuery = this.searchTagQuery.bind(this);
+
+    this.handleResultsRender = this.handleResultsRender.bind(this);
+    this.resetCards = this.resetCards.bind(this);
+    this.updateCards = this.updateCards.bind(this);
   }
+
+  /** Begin functions for sorting menu on top of the page */
+
+  /** TODO(fatimazali): Create re-usable search filtering component */
+
+  /** Update a stringQuery and search the cards by the specified query variable */
+  handleStringSearch = (queryName, event) => {
+    // queryName is used instead of event.target.name or event.target.id
+    // since both onChange and onSelect call this function with id and name
+    const { value } = event.target;
+    if (value === "") {
+      return;
+    }
+    this.setState(
+      {
+        [queryName]: value,
+      },
+      this.simpleSearch(queryName, value)
+    );
+  };
+
+  /** Search the cards by the current tagQueries. */
+  searchTagQuery = () => {
+    this.state.tagsQuery.map((item) => this.simpleSearch("tags-search", item));
+  };
+
+  /** Combine all tags in filteredData items to update tags that user can select */
+  populateAllTags = () => {
+    const { filteredData } = this.state;
+    var populatedTags = [];
+    filteredData.map((data) =>
+      populatedTags.push.apply(populatedTags, data.foodbankTags)
+    );
+    // Get unique tags only
+    const populatedUniqueTags = [...new Set(populatedTags)];
+
+    this.setState({
+      allTags: populatedUniqueTags,
+    });
+  };
+
+  /** Update tagQueries and search the cards by tags */
+  handleTagFilter = (event, values) => {
+    if (values.length === 0) {
+      return;
+    }
+    const prevValues = this.state.tagsQuery;
+    // If the user has removed one of the previous tags, reset all search queries
+    if (values.length < prevValues.length) {
+      this.resetCards();
+    } else {
+      this.setState(
+        {
+          // Search state
+          tagsQuery: [...values],
+        },
+        // Use callback to ensure that tagsQuery has updated before searching tags
+        // Avoid adding parameters: it causes timing issues with the callback
+        this.searchTagQuery
+      );
+    }
+  };
+
+  /** Makes appropriate search by field and query of the data, updates filtered page states */
+  simpleSearch = (field, query) => {
+    var multiFilteredData = [];
+
+    switch (field) {
+      case "nameQuery":
+        multiFilteredData = this.state.filteredData.filter((item) =>
+          item.foodbankName.toLowerCase().includes(query.toLowerCase())
+        );
+        break;
+      case "locationQuery":
+        multiFilteredData = this.state.filteredData.filter((item) =>
+          item.location.toLowerCase().includes(query.toLowerCase())
+        );
+        break;
+      case "tags-search":
+        multiFilteredData = this.state.filteredData.filter((item) =>
+          item.foodbankTags.includes(query)
+        );
+        break;
+    }
+
+    this.setState(
+      { filteredData: multiFilteredData },
+      // Update tags with newly filtered data
+      this.populateAllTags
+    );
+  };
+
+  /** Returns additional search features that are collapsed at first glance */
+  extraFiltersAccordion = () => {
+    const { locationQuery, filteredData } = this.state;
+
+    return (
+      <div>
+        <div>
+          <Autocomplete
+            id="location-search"
+            options={filteredData.map((data) => data.location)}
+            value={locationQuery}
+            onSelect={(e) => this.handleStringSearch("locationQuery", e)}
+            fullWidth={true}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Food Bank Locations"
+                placeholder="Type or Select a Location"
+                variant="outlined"
+                onChange={(e) => this.handleStringSearch("locationQuery", e)}
+                InputProps={{
+                  ...params.InputProps,
+                  startAdornment: (
+                    <>
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                      {params.InputProps.startAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+          />
+        </div>
+        <div>{this.tagsAutocomplete(false)}</div>
+        <Filters database="foodbanks"></Filters>
+      </div>
+    );
+  };
+
+  /** Returns the accordion menu that contains all search and filtering options */
+  filteringAccordion = () => {
+    const { classes } = this.props;
+    const { nameQuery, filteredData } = this.state;
+
+    return (
+      <div>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Autocomplete
+              id="nameQuery"
+              options={[
+                ...new Set(filteredData.map((data) => data.foodbankName)),
+              ]}
+              value={nameQuery}
+              onSelect={(e) => this.handleStringSearch("nameQuery", e)}
+              fullWidth={true}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Foodbank Names"
+                  placeholder="Type or Select a Food Bank Name"
+                  variant="outlined"
+                  name="nameQuery"
+                  onChange={(e) => this.handleStringSearch("nameQuery", e)}
+                  InputProps={{
+                    ...params.InputProps,
+                    startAdornment: (
+                      <>
+                        <InputAdornment position="start">
+                          <SearchIcon />
+                        </InputAdornment>
+                        {params.InputProps.startAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+            />
+          </AccordionSummary>
+          <AccordionDetails>{this.extraFiltersAccordion()}</AccordionDetails>
+          <Grid container alignItem="left">
+            <Grid item xs={12}>
+              <Box paddingLeft={2} paddingBottom={2}>
+                <Button
+                  className={classes.clearSearchButton}
+                  onClick={this.resetCards}
+                  variant="contained"
+                  color="primary"
+                  size="medium"
+                  startIcon={<ClearIcon />}
+                >
+                  Clear
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </Accordion>
+      </div>
+    );
+  };
+
+  /**
+   * Returns tag filtering menu for searching cards.
+   * Re-using the autocomplete for the add new/edit item form
+   * causes issues with setting a conditional value for
+   * Autocomplete value={}, so separating the two is smoother.
+   */
+  tagsAutocomplete = () => {
+    const { classes } = this.props;
+    const { allTags, tagsQuery } = this.state;
+
+    return (
+      <Autocomplete
+        className={classes.searchBars}
+        multiple
+        id="tags-search"
+        onChange={this.handleTagFilter}
+        options={allTags}
+        value={tagsQuery}
+        fullWidth
+        renderTags={(value, getTagProps) =>
+          value.map((option, index) => (
+            <Chip label={option} {...getTagProps({ index })} />
+          ))
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label="Food Bank Tags"
+            placeholder="Type or Select a Food Bank Tag"
+            InputProps={{
+              ...params.InputProps,
+              startAdornment: (
+                <>
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                  {params.InputProps.startAdornment}
+                </>
+              ),
+            }}
+          />
+        )}
+      />
+    );
+  };
+
+  /** Updates filteredData with a new array; used with filters.js queries */
+  updateCards = (newValues) => {
+    if (newValues.length === 0) {
+      return;
+    }
+    this.setState({
+      filteredData: [...newValues],
+    });
+  };
+
+  /** Reset filteredData to the original page data, upon clicking reset */
+  resetCards = () => {
+    this.props.clearQueries();
+    this.setState(
+      {
+        filteredData: [...this.state.foodbanks],
+        nameQuery: "",
+        locationQuery: "",
+        tagsQuery: [],
+      },
+      this.populateAllTags
+    );
+  };
+
+  /** End functions for sorting menu on top of the page */
+  /** Renders filtered produce results into Material-UI cards */
+  handleResultsRender = () => {
+    const { classes } = this.props;
+    const { filteredData } = this.state;
+
+    return (
+      <div>
+        <Grid container spacing={2} alignItem="center">
+          {this.state.foodbanks.map((foodbank) => (
+            <Grid item xs={12}>
+              <Card
+                className={classes.root}
+                raised={foodbank.foodbankId === this.state.selectedCard}
+                variant={
+                  foodbank.foodbankId === this.state.selectedCard
+                    ? "elevation"
+                    : "outlined"
+                }
+              >
+                <CardContent>
+                  <Typography variant="h5" component="h2">
+                    {foodbank.foodbankName}
+                  </Typography>
+                  {foodbank.foodbankTags.map((tag) => (
+                    <Chip className={classes.chip} label={tag} size="small" />
+                  ))}
+                  <Box
+                    display="flex"
+                    flexDirection="row"
+                    flexWrap="wrap"
+                    padding={0}
+                    margin={0}
+                  >
+                    <Box padding={3}>
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
+                        Details:
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        component="p"
+                        className={classes.foodbankLocation}
+                      >
+                        Location of Food Bank: {foodbank.location}
+                        <br />
+                        Refrigeration Space (in pallets):
+                        {foodbank.refrigerationSpaceAvailable}
+                        <br />
+                        Max Load Size (in pallets): {foodbank.maxLoadSize}
+                      </Typography>
+                    </Box>
+                    {/* TODO(andrewhojel): allow user to choose the point of contact! */}
+                    {foodbank.contacts.length > 0 && (
+                      <Box padding={3}>
+                        <Typography
+                          className={classes.position}
+                          color="textSecondary"
+                        >
+                          Point of Contact:
+                        </Typography>
+                        <Typography variant="body2" component="p">
+                          Role: {foodbank.contacts[0]["contactRole"]}
+                          <br />
+                          Name: {foodbank.contacts[0]["contactName"]}
+                          <br />
+                          Phone: {foodbank.contacts[0]["contactPhone"]}
+                          <br />
+                          Email: {foodbank.contacts[0]["contactEmail"]}
+                        </Typography>
+                      </Box>
+                    )}
+                    <Box padding={3}>
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
+                        Logistics:
+                      </Typography>
+                      <Typography variant="body2" component="p">
+                        Forklift: {foodbank.forklift ? "yes" : "no"}
+                        <br />
+                        Pallet: {foodbank.pallet ? "yes" : "no"}
+                        <br />
+                        Loading Dock: {foodbank.loadingDock ? "yes" : "no"}
+                      </Typography>
+                    </Box>
+                    {/* DETERMINE(andrewhojel): do we include hours of foodbanks? */}
+                  </Box>
+                </CardContent>
+                <CardActions>
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleViewOpen({ foodbank })}
+                    >
+                      View
+                    </Button>
+                  )}
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleEditClick({ foodbank })}
+                    >
+                      Edit
+                    </Button>
+                  )}
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleDelete({ foodbank })}
+                    >
+                      Delete
+                    </Button>
+                  )}
+                  {this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleSelect({ foodbank })}
+                    >
+                      Select
+                    </Button>
+                  )}
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </div>
+    );
+  };
 
   /**
    * Given an event, this function updates a state (the target of the event)
@@ -306,9 +750,17 @@ class Foodbank extends Component {
     axios
       .get("/foodbanks")
       .then((response) => {
+        this.setState(
+          {
+            foodbanks: response.data,
+            filteredData: response.data,
+            uiLoading: false,
+          },
+          this.populateAllTags
+        );
+
         this.setState({
-          foodbanks: response.data,
-          uiLoading: false,
+          unfilteredTags: [...this.state.allTags],
         });
       })
       .catch((err) => {
@@ -425,11 +877,12 @@ class Foodbank extends Component {
     dayjs.extend(relativeTime);
     const { classes } = this.props;
     const { open, errors, viewOpen } = this.state;
+    const { unfilteredTags } = this.state;
 
     /** Set all states to generic value when opening a dialog page */
     const handleAddClick = () => {
       this.setState({
-        // food bank states
+        // Food bank states
         foodbankName: "",
         location: "",
         locationId: "",
@@ -442,7 +895,7 @@ class Foodbank extends Component {
         maxLoadSize: "",
         refrigerationSpaceAvailable: "",
         foodbankTags: [],
-        // page state
+        // Page state
         open: true,
       });
       tableState.data = [];
@@ -605,6 +1058,7 @@ class Foodbank extends Component {
                     <Address
                       handleLocation={this.handleLocation}
                       location={this.state.location}
+                      searching={false}
                     />
                     {/* can we get the hours from the location query? */}
                   </Grid>
@@ -716,7 +1170,7 @@ class Foodbank extends Component {
                       multiple
                       id="foodbankTags"
                       onChange={this.onTagsChange}
-                      options={TAG_EXAMPLES.map((option) => option.title)}
+                      options={unfilteredTags}
                       defaultValue={[this.state.foodbankTags]}
                       freeSolo
                       renderTags={(value, getTagProps) =>
@@ -749,153 +1203,10 @@ class Foodbank extends Component {
           <Container maxWidth="lg">
             <Grid container spacing={2} alignItem="center">
               <Grid item xs={12}>
-                <div className={classes.search}>
-                  <div className={classes.searchIcon}>
-                    <SearchIcon />
-                  </div>
-                  <InputBase
-                    fullWidth={true}
-                    placeholder="Search…"
-                    classes={{
-                      root: classes.inputRoot,
-                      input: classes.inputInput,
-                    }}
-                    inputProps={{ "aria-label": "search" }}
-                  />
-                </div>
+                {this.filteringAccordion()}
               </Grid>
-              {this.state.foodbanks.map((foodbank) => (
-                <Grid item xs={12}>
-                  <Card
-                    className={classes.root}
-                    raised={foodbank.foodbankId === this.state.selectedCard}
-                    variant={
-                      foodbank.foodbankId === this.state.selectedCard
-                        ? "elevation"
-                        : "outlined"
-                    }
-                  >
-                    <CardContent>
-                      <Typography variant="h5" component="h2">
-                        {foodbank.foodbankName}
-                      </Typography>
-                      <Chip
-                        className={classes.chip}
-                        label="High Food Insecurity"
-                        size="small"
-                      />
-                      <Chip
-                        className={classes.chip}
-                        label="Major City"
-                        size="small"
-                      />
-                      <Box
-                        display="flex"
-                        flexDirection="row"
-                        flexWrap="wrap"
-                        p={0}
-                        m={0}
-                      >
-                        <Box p={3}>
-                          <Typography
-                            className={classes.pos}
-                            color="textSecondary"
-                          >
-                            Details:
-                          </Typography>
-                          <Typography
-                            variant="body2"
-                            component="p"
-                            className={classes.foodbankLocation}
-                          >
-                            Location of Food Bank: {foodbank.location}
-                            <br />
-                            Refrigeration Space (in pallets):
-                            {foodbank.refrigerationSpaceAvailable}
-                            <br />
-                            Max Load Size (in pallets): {foodbank.maxLoadSize}
-                          </Typography>
-                        </Box>
-                        {/* TODO(andrewhojel): allow user to choose the point of contact! */}
-                        {foodbank.contacts.length > 0 && (
-                          <Box p={3}>
-                            <Typography
-                              className={classes.pos}
-                              color="textSecondary"
-                            >
-                              Point of Contact:
-                            </Typography>
-                            <Typography variant="body2" component="p">
-                              Role: {foodbank.contacts[0]["contactRole"]}
-                              <br />
-                              Name: {foodbank.contacts[0]["contactName"]}
-                              <br />
-                              Phone: {foodbank.contacts[0]["contactPhone"]}
-                              <br />
-                              Email: {foodbank.contacts[0]["contactEmail"]}
-                            </Typography>
-                          </Box>
-                        )}
-                        <Box p={3}>
-                          <Typography
-                            className={classes.pos}
-                            color="textSecondary"
-                          >
-                            Logistics:
-                          </Typography>
-                          <Typography variant="body2" component="p">
-                            Forklift: {foodbank.forklift ? "yes" : "no"}
-                            <br />
-                            Pallet: {foodbank.pallet ? "yes" : "no"}
-                            <br />
-                            Loading Dock: {foodbank.loadingDock ? "yes" : "no"}
-                          </Typography>
-                        </Box>
-                        {/* DETERMINE(andrewhojel): do we include hours of foodbanks? */}
-                      </Box>
-                    </CardContent>
-                    <CardActions>
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleViewOpen({ foodbank })}
-                        >
-                          View
-                        </Button>
-                      )}
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleEditClick({ foodbank })}
-                        >
-                          Edit
-                        </Button>
-                      )}
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleDelete({ foodbank })}
-                        >
-                          Delete
-                        </Button>
-                      )}
-                      {this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleSelect({ foodbank })}
-                        >
-                          Select
-                        </Button>
-                      )}
-                    </CardActions>
-                  </Card>
-                </Grid>
-              ))}
             </Grid>
+            {this.handleResultsRender()}
           </Container>
 
           <Dialog
@@ -919,11 +1230,14 @@ class Foodbank extends Component {
                 display="flex"
                 flexDirection="row"
                 flexWrap="wrap"
-                p={0}
-                m={0}
+                padding={0}
+                margin={0}
               >
-                <Box p={3}>
-                  <Typography className={classes.pos} color="textSecondary">
+                <Box padding={3}>
+                  <Typography
+                    className={classes.position}
+                    color="textSecondary"
+                  >
                     Details:
                   </Typography>
                   <Typography variant="body2" component="p">
@@ -935,8 +1249,11 @@ class Foodbank extends Component {
                     Max Load Size (in pallets): {this.state.maxLoadSize}
                   </Typography>
                 </Box>
-                <Box p={3}>
-                  <Typography className={classes.pos} color="textSecondary">
+                <Box padding={3}>
+                  <Typography
+                    className={classes.position}
+                    color="textSecondary"
+                  >
                     Logistics:
                   </Typography>
                   <Typography variant="body2" component="p">

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -546,7 +546,7 @@ class Foodbank extends Component {
     return (
       <div>
         <Grid container spacing={2} alignItem="center">
-          {this.state.foodbanks.map((foodbank) => (
+          {this.state.filteredData.map((foodbank) => (
             <Grid item xs={12}>
               <Card
                 className={classes.root}

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -269,8 +269,6 @@ class Foodbank extends Component {
     this.updateCards = this.updateCards.bind(this);
   }
 
-  /** Begin functions for sorting menu on top of the page */
-
   /** TODO(fatimazali): Create re-usable search filtering component */
 
   /** Update a stringQuery and search the cards by the specified query variable */
@@ -278,15 +276,14 @@ class Foodbank extends Component {
     // queryName is used instead of event.target.name or event.target.id
     // since both onChange and onSelect call this function with id and name
     const { value } = event.target;
-    if (value === "") {
-      return;
+    if (value) {
+      this.setState(
+        {
+          [queryName]: value,
+        },
+        this.simpleSearch(queryName, value)
+      );
     }
-    this.setState(
-      {
-        [queryName]: value,
-      },
-      this.simpleSearch(queryName, value)
-    );
   };
 
   /** Search the cards by the current tagQueries. */
@@ -294,10 +291,10 @@ class Foodbank extends Component {
     this.state.tagsQuery.map((item) => this.simpleSearch("tags-search", item));
   };
 
-  /** Combine all tags in filteredData items to update tags that user can select */
+  /** Combine all tags in filteredData items to update tags that users can select */
   populateAllTags = () => {
     const { filteredData } = this.state;
-    var populatedTags = [];
+    let populatedTags = [];
     filteredData.map((data) =>
       populatedTags.push.apply(populatedTags, data.foodbankTags)
     );
@@ -311,7 +308,7 @@ class Foodbank extends Component {
 
   /** Update tagQueries and search the cards by tags */
   handleTagFilter = (event, values) => {
-    if (values.length === 0) {
+    if (values && values.length === 0) {
       return;
     }
     const prevValues = this.state.tagsQuery;
@@ -519,7 +516,9 @@ class Foodbank extends Component {
 
   /** Updates filteredData with a new array; used with filters.js queries */
   updateCards = (newValues) => {
-    if (newValues.length === 0) {
+    // newValues comes from filters.js and will be an array currently
+    // If adding more functionality to updateCards(), add more boundary value checks
+    if (newValues && newValues.length === 0) {
       return;
     }
     this.setState({
@@ -540,7 +539,6 @@ class Foodbank extends Component {
     );
   };
 
-  /** End functions for sorting menu on top of the page */
   /** Renders filtered produce results into Material-UI cards */
   handleResultsRender = () => {
     const { classes } = this.props;

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -366,36 +366,40 @@ class Foodbank extends Component {
 
     return (
       <div>
-        <div>
-          <Autocomplete
-            id="location-search"
-            options={filteredData.map((data) => data.location)}
-            value={locationQuery}
-            onSelect={(e) => this.handleStringSearch("locationQuery", e)}
-            fullWidth={true}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Food Bank Locations"
-                placeholder="Type or Select a Location"
-                variant="outlined"
-                onChange={(e) => this.handleStringSearch("locationQuery", e)}
-                InputProps={{
-                  ...params.InputProps,
-                  startAdornment: (
-                    <>
-                      <InputAdornment position="start">
-                        <SearchIcon />
-                      </InputAdornment>
-                      {params.InputProps.startAdornment}
-                    </>
-                  ),
-                }}
-              />
-            )}
-          />
-        </div>
-        <div>{this.tagsAutocomplete(false)}</div>
+        <Grid container spacing={3} alignItem="left">
+          <Grid item xs={6}>
+            <Autocomplete
+              id="location-search"
+              options={filteredData.map((data) => data.location)}
+              value={locationQuery}
+              onSelect={(e) => this.handleStringSearch("locationQuery", e)}
+              fullWidth={true}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Food Bank Locations"
+                  placeholder="Type or Select a Location"
+                  variant="outlined"
+                  onChange={(e) => this.handleStringSearch("locationQuery", e)}
+                  InputProps={{
+                    ...params.InputProps,
+                    startAdornment: (
+                      <>
+                        <InputAdornment position="start">
+                          <SearchIcon />
+                        </InputAdornment>
+                        {params.InputProps.startAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            {this.tagsAutocomplete()}
+          </Grid>
+        </Grid>
         <Filters database="foodbanks"></Filters>
       </div>
     );
@@ -479,7 +483,6 @@ class Foodbank extends Component {
 
     return (
       <Autocomplete
-        className={classes.searchBars}
         multiple
         id="tags-search"
         onChange={this.handleTagFilter}

--- a/view/src/extras/address_autocomplete_field.js
+++ b/view/src/extras/address_autocomplete_field.js
@@ -187,7 +187,7 @@ export default function AddressAutocompleteField(props) {
           fullWidth
           InputProps={
             !props.searching
-              ? null
+              ? { ...params.InputProps }
               : {
                   ...params.InputProps,
                   startAdornment: (


### PR DESCRIPTION
![React App (3)](https://user-images.githubusercontent.com/43034257/91949992-1ee85600-ecb5-11ea-9dc6-c136c162f021.gif)

- Added multi-filters from farms.js, updated variable names, changed certain Search State names to be more re-usable between pages
- Fixed InputProps non-searching usage of Address Autocomplete component

Changes within search functions that I made, to differentiate from the search functions in farms.js: 
(Will do these in their own commits on the next pages, my apologies!)
(Also, for making a re-usable search component in the future, these should be kept in mind)
- Inside simpleSearch: update search fields to foodbank database specific fields
- In each Autocomplete search bar, I updated the textFieldLabel and placeholder text with "Food bank" 

Future additions, if time permits: 
- Enter a min load size and available fridge space

Bug fix: 
- When adding a new farm bank, there was a default empty tag added to the tags form, and it causes an error when submitting. I had to get rid of the empty tag to be able to submit.
- This issue was because the Autocomplete's defaultValue={[this.state.foodbankTags]} -- getting rid of the [] typecasting solved it
- I'll add this to the other pages as I go along, wanted to note it in case it is elsewhere

PR #58 Note:
- Removed props.clearQueries() from resetCards(): will add back in when integrating data flow between Filters component and pages
