### PR TITLE
Add search for surplus: originFarmName, destinationFoodBankName, packagingType

### DIFF
--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -137,7 +137,7 @@ class Filters extends Component {
             handleLocation={this.handleLocation}
             location={this.state.location}
             searching={true}
-            PlaceholderText="Type or Select a Location to find Nearby Farms"
+            PlaceholderText="Type or Select a Location to Search Nearby"
             TextFieldLabel="Custom Location"
           />
         </Grid>

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -223,6 +223,8 @@ class Foodbank extends Component {
       filteredData: [],
       nameQuery: "",
       locationQuery: "",
+      loadSizeQuery: 0,
+      fridgeSpaceQuery: 0,
       tagsQuery: [],
       allTags: [],
       // Aggregated tags used for options when editing a specific item
@@ -328,6 +330,64 @@ class Foodbank extends Component {
     }
   };
 
+  /** Filters for minimum load size and available refridgeration space */
+  capacityFilters = () => {
+    return (
+      <Grid container spacing={3} alignItem="left">
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
+            label="Fridge Space (Pallets)"
+            name="fridgeSpaceQuery"
+            type="number"
+            value={this.state.fridgeSpaceQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={() =>
+              this.simpleSearch("fridgeSpaceQuery", this.state.fridgeSpaceQuery)
+            }
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Fridge Space
+          </Button>
+        </Grid>
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
+            label="Load Size (Pallets)"
+            name="loadSizeQuery"
+            type="number"
+            value={this.state.loadSizeQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={() =>
+              this.simpleSearch("loadSizeQuery", this.state.loadSizeQuery)
+            }
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Load Size
+          </Button>
+        </Grid>
+      </Grid>
+    );
+  };
+
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
@@ -346,6 +406,16 @@ class Foodbank extends Component {
       case "tags-search":
         multiFilteredData = this.state.filteredData.filter((item) =>
           item.foodbankTags.includes(query)
+        );
+        break;
+      case "loadSizeQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.maxLoadSize) > query
+        );
+        break;
+      case "fridgeSpaceQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.refrigerationSpaceAvailable) > query
         );
         break;
     }
@@ -399,6 +469,7 @@ class Foodbank extends Component {
           </Grid>
         </Grid>
         <Filters database="foodbanks"></Filters>
+        {this.capacityFilters()}
       </div>
     );
   };
@@ -534,6 +605,8 @@ class Foodbank extends Component {
         filteredData: [...this.state.foodbanks],
         nameQuery: "",
         locationQuery: "",
+        loadSizeQuery: 0,
+        fridgeSpaceQuery: 0,
         tagsQuery: [],
       },
       this.populateAllTags

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -331,6 +331,7 @@ class Foodbank extends Component {
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
+    const parsedQuery = query.toLowerCase();
 
     switch (field) {
       case "nameQuery":
@@ -356,10 +357,12 @@ class Foodbank extends Component {
       this.populateAllTags
     );
   };
+  };
 
   /** Returns additional search features that are collapsed at first glance */
   extraFiltersAccordion = () => {
-    const { locationQuery, filteredData } = this.state;
+    const { classes } = this.props;
+    const { nameQuery, filteredData } = this.state;
 
     return (
       <div>

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -260,7 +260,7 @@ class Foodbank extends Component {
     this.handleStringSearch = this.handleStringSearch.bind(this);
     this.simpleSearch = this.simpleSearch.bind(this);
 
-    this.populateAllFTags = this.populateAllTags.bind(this);
+    this.populateAllTags = this.populateAllTags.bind(this);
     this.handleTagFilter = this.handleTagFilter.bind(this);
     this.searchTagQuery = this.searchTagQuery.bind(this);
 

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -331,7 +331,6 @@ class Foodbank extends Component {
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
-    const parsedQuery = query.toLowerCase();
 
     switch (field) {
       case "nameQuery":
@@ -357,12 +356,11 @@ class Foodbank extends Component {
       this.populateAllTags
     );
   };
-  };
 
   /** Returns additional search features that are collapsed at first glance */
   extraFiltersAccordion = () => {
     const { classes } = this.props;
-    const { nameQuery, filteredData } = this.state;
+    const { locationQuery, filteredData } = this.state;
 
     return (
       <div>

--- a/view/src/components/produce.js
+++ b/view/src/components/produce.js
@@ -290,56 +290,32 @@ class Produce extends Component {
 
     return (
       <div>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1a-content"
-            id="panel1a-header"
-          >
-            <Typography className={classes.heading}>Search by Name</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Autocomplete
-              id="produce-name-search"
-              options={data.map((produce) => produce.name)}
-              value={value}
-              onSelect={this.handleSearch} // Receive the name from data element for value
-              fullWidth={true}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Produce Names"
-                  variant="outlined"
-                  onChange={this.handleSearch}
-                  InputProps={{
-                    ...params.InputProps,
-                    startAdornment: (
-                      <>
-                        <InputAdornment position="start">
-                          <SearchIcon />
-                        </InputAdornment>
-                        {params.InputProps.startAdornment}
-                      </>
-                    ),
-                  }}
-                />
-              )}
+        <Autocomplete
+          id="produce-name-search"
+          options={data.map((produce) => produce.name)}
+          value={value}
+          onSelect={this.handleSearch} // Receive the name from data element for value
+          fullWidth={true}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Produce Names"
+              variant="outlined"
+              onChange={this.handleSearch}
+              InputProps={{
+                ...params.InputProps,
+                startAdornment: (
+                  <>
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                    {params.InputProps.startAdornment}
+                  </>
+                ),
+              }}
             />
-          </AccordionDetails>
-        </Accordion>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2a-content"
-            id="panel2a-header"
-          >
-            <Typography className={classes.heading}>Filter by Tags</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            {/* TODO(fatimazali): Add tag filtering) */}
-            <Typography>Select tags to filter by:</Typography>
-          </AccordionDetails>
-        </Accordion>
+          )}
+        />
       </div>
     );
   };

--- a/view/src/components/surplus.js
+++ b/view/src/components/surplus.js
@@ -226,7 +226,6 @@ class Surplus extends Component {
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
     const parsedQuery = query.toLowerCase();
-    console.log("ss query is", parsedQuery);
 
     switch (field) {
       case "farmNameQuery":

--- a/view/src/components/surplus.js
+++ b/view/src/components/surplus.js
@@ -169,7 +169,7 @@ class Surplus extends Component {
       filteredData: [],
       farmNameQuery: "",
       produceNameQuery: "",
-      originFarmContactNameQuery: "",
+      packagingTypeQuery: "",
       // Surplus state
       surplusObjects: "",
       surplusId: "",
@@ -200,10 +200,6 @@ class Surplus extends Component {
     this.handleStringSearch = this.handleStringSearch.bind(this);
     this.simpleSearch = this.simpleSearch.bind(this);
 
-    this.populateAllFTags = this.populateAllTags.bind(this);
-    this.handleTagFilter = this.handleTagFilter.bind(this);
-    this.searchTagQuery = this.searchTagQuery.bind(this);
-
     this.handleResultsRender = this.handleResultsRender.bind(this);
     this.resetCards = this.resetCards.bind(this);
     this.updateCards = this.updateCards.bind(this);
@@ -226,52 +222,11 @@ class Surplus extends Component {
     }
   };
 
-  /** Search the cards by the current tagQueries. */
-  searchTagQuery = () => {
-    this.state.tagsQuery.map((item) => this.simpleSearch("tags-search", item));
-  };
-
-  /** Combine all tags in filteredData items to update tags that users can select */
-  populateAllTags = () => {
-    const { filteredData } = this.state;
-    let populatedTags = [];
-    filteredData.map((data) =>
-      populatedTags.push.apply(populatedTags, data.foodbankTags)
-    );
-    // Get unique tags only
-    const populatedUniqueTags = [...new Set(populatedTags)];
-
-    this.setState({
-      allTags: populatedUniqueTags,
-    });
-  };
-
-  /** Update tagQueries and search the cards by tags */
-  handleTagFilter = (event, values) => {
-    if (values && values.length === 0) {
-      return;
-    }
-    const prevValues = this.state.tagsQuery;
-    // If the user has removed one of the previous tags, reset all search queries
-    if (values.length < prevValues.length) {
-      this.resetCards();
-    } else {
-      this.setState(
-        {
-          // Search state
-          tagsQuery: [...values],
-        },
-        // Use callback to ensure that tagsQuery has updated before searching tags
-        // Avoid adding parameters: it causes timing issues with the callback
-        this.searchTagQuery
-      );
-    }
-  };
-
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
     const parsedQuery = query.toLowerCase();
+    console.log("ss query is", parsedQuery);
 
     switch (field) {
       case "farmNameQuery":
@@ -284,9 +239,9 @@ class Surplus extends Component {
           item.produceName.toLowerCase().includes(parsedQuery)
         );
         break;
-      case "originFarmContactNameQuery":
+      case "packagingTypeQuery":
         multiFilteredData = this.state.filteredData.filter((item) =>
-          item.originFarmContactName.toLowerCase().includes(parsedQuery)
+          item.packagingType.toLowerCase().includes(parsedQuery)
         );
         break;
     }
@@ -296,87 +251,79 @@ class Surplus extends Component {
 
   /** Returns additional search features that are collapsed at first glance */
   extraFiltersAccordion = () => {
-    const {
-      produceNameQuery,
-      originFarmContactNameQuery,
-      filteredData,
-    } = this.state;
+    const { produceNameQuery, packagingTypeQuery, filteredData } = this.state;
     return (
-      <div>
-        <Grid container spacing={3} alignItem="left">
-          <Grid item xs={6}>
-            <Autocomplete
-              id="produce-search"
-              options={filteredData.map((data) => data.produceName)}
-              value={produceNameQuery}
-              onSelect={(e) => this.handleStringSearch("produceNameQuery", e)}
-              fullWidth={true}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Produce Names"
-                  placeholder="Type or Select a Produce Name"
-                  variant="outlined"
-                  onChange={(e) =>
-                    this.handleStringSearch("produceNameQuery", e)
-                  }
-                  InputProps={{
-                    ...params.InputProps,
-                    startAdornment: (
-                      <>
-                        <InputAdornment position="start">
-                          <SearchIcon />
-                        </InputAdornment>
-                        {params.InputProps.startAdornment}
-                      </>
-                    ),
-                  }}
-                />
-              )}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            <Autocomplete
-              id="contact-search"
-              options={filteredData.map((data) => data.originFarmContactName)}
-              value={originFarmContactNameQuery}
-              onSelect={(e) =>
-                this.handleStringSearch("originFarmContactNameQuery", e)
-              }
-              fullWidth={true}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Farm Contact Names"
-                  placeholder="Type or Select a Farm Contact Name"
-                  variant="outlined"
-                  onChange={(e) =>
-                    this.handleStringSearch("originFarmContactNameQuery", e)
-                  }
-                  InputProps={{
-                    ...params.InputProps,
-                    startAdornment: (
-                      <>
-                        <InputAdornment position="start">
-                          <SearchIcon />
-                        </InputAdornment>
-                        {params.InputProps.startAdornment}
-                      </>
-                    ),
-                  }}
-                />
-              )}
-            />
-          </Grid>
+      <Grid container spacing={3} alignItem="left">
+        <Grid item xs={6}>
+          <Autocomplete
+            id="produce-search"
+            options={[...new Set(filteredData.map((data) => data.produceName))]}
+            value={produceNameQuery}
+            onSelect={(e) => this.handleStringSearch("produceNameQuery", e)}
+            fullWidth={true}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Produce Names"
+                placeholder="Type or Select a Produce Name"
+                variant="outlined"
+                onChange={(e) => this.handleStringSearch("produceNameQuery", e)}
+                InputProps={{
+                  ...params.InputProps,
+                  startAdornment: (
+                    <>
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                      {params.InputProps.startAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+          />
         </Grid>
-      </div>
+        <Grid item xs={6}>
+          <Autocomplete
+            id="packaging-type-search"
+            options={[
+              ...new Set(filteredData.map((data) => data.packagingType)),
+            ]}
+            value={packagingTypeQuery}
+            onSelect={(e) => this.handleStringSearch("packagingTypeQuery", e)}
+            fullWidth={true}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Packaging Types"
+                placeholder="Type or Select a Packaging Type"
+                variant="outlined"
+                onChange={(e) =>
+                  this.handleStringSearch("packagingTypeQuery", e)
+                }
+                InputProps={{
+                  ...params.InputProps,
+                  startAdornment: (
+                    <>
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                      {params.InputProps.startAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+          />
+        </Grid>
+      </Grid>
     );
   };
 
   /** Returns the accordion menu that contains all search and filtering options */
   filteringAccordion = () => {
     const { classes } = this.props;
-    const { nameQuery, filteredData } = this.state;
+    const { farmNameQuery, filteredData } = this.state;
     return (
       <div>
         <Accordion>
@@ -390,14 +337,14 @@ class Surplus extends Component {
               options={[
                 ...new Set(filteredData.map((data) => data.originFarmName)),
               ]}
-              value={nameQuery}
+              value={farmNameQuery}
               onSelect={(e) => this.handleStringSearch("farmNameQuery", e)}
               fullWidth={true}
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  label="Foodbank Names"
-                  placeholder="Type or Select a Farm Name"
+                  label="Origin Farm Names"
+                  placeholder="Type or Select an Origin Farm Name"
                   variant="outlined"
                   name="farmNameQuery"
                   onChange={(e) => this.handleStringSearch("farmNameQuery", e)}
@@ -438,52 +385,6 @@ class Surplus extends Component {
     );
   };
 
-  /**
-   * Returns tag filtering menu for searching cards.
-   * Re-using the autocomplete for the add new/edit item form
-   * causes issues with setting a conditional value for
-   * Autocomplete value={}, so separating the two is smoother.
-   */
-  tagsAutocomplete = () => {
-    const { classes } = this.props;
-    const { allTags, tagsQuery } = this.state;
-
-    return (
-      <Autocomplete
-        multiple
-        id="tags-search"
-        onChange={this.handleTagFilter}
-        options={allTags}
-        value={tagsQuery}
-        fullWidth
-        renderTags={(value, getTagProps) =>
-          value.map((option, index) => (
-            <Chip label={option} {...getTagProps({ index })} />
-          ))
-        }
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label="Food Bank Tags"
-            placeholder="Type or Select a Food Bank Tag"
-            InputProps={{
-              ...params.InputProps,
-              startAdornment: (
-                <>
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                  {params.InputProps.startAdornment}
-                </>
-              ),
-            }}
-          />
-        )}
-      />
-    );
-  };
-
   /** Updates filteredData with a new array; used with filters.js queries */
   updateCards = (newValues) => {
     // newValues comes from filters.js and will be an array currently
@@ -498,15 +399,12 @@ class Surplus extends Component {
 
   /** Reset filteredData to the original page data, upon clicking reset */
   resetCards = () => {
-    this.setState(
-      {
-        filteredData: [...this.state.foodbanks],
-        nameQuery: "",
-        locationQuery: "",
-        tagsQuery: [],
-      },
-      this.populateAllTags
-    );
+    this.setState({
+      filteredData: [...this.state.surplusObjects],
+      farmNameQuery: "",
+      produceNameQuery: "",
+      packagingTypeQuery: "",
+    });
   };
 
   /** Renders filtered produce results into Material-UI cards */
@@ -517,7 +415,7 @@ class Surplus extends Component {
     return (
       <div>
         <Grid container spacing={2} alignItem="center">
-          {this.state.filteredData.map((surplus) => (
+          {filteredData.map((surplus) => (
             <Grid item xs={12}>
               <Card
                 className={classes.root}
@@ -688,6 +586,7 @@ class Surplus extends Component {
       .then((response) => {
         this.setState({
           surplusObjects: response.data,
+          filteredData: response.data,
           uiLoading: false,
         });
       })

--- a/view/src/components/surplus.js
+++ b/view/src/components/surplus.js
@@ -29,6 +29,10 @@ import AccordionSummary from "@material-ui/core/AccordionSummary";
 import AccordionDetails from "@material-ui/core/AccordionDetails";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ClearIcon from "@material-ui/icons/Clear";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import Chip from "@material-ui/core/Chip";
+import TextField from "@material-ui/core/TextField";
 
 import axios from "axios";
 import dayjs from "dayjs";
@@ -267,53 +271,55 @@ class Surplus extends Component {
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
+    const parsedQuery = query.toLowerCase();
 
     switch (field) {
-      case "nameQuery":
+      case "farmNameQuery":
         multiFilteredData = this.state.filteredData.filter((item) =>
-          item.foodbankName.toLowerCase().includes(query.toLowerCase())
+          item.originFarmName.toLowerCase().includes(parsedQuery)
         );
         break;
-      case "locationQuery":
+      case "produceNameQuery":
         multiFilteredData = this.state.filteredData.filter((item) =>
-          item.location.toLowerCase().includes(query.toLowerCase())
+          item.produceName.toLowerCase().includes(parsedQuery)
         );
         break;
-      case "tags-search":
+      case "originFarmContactNameQuery":
         multiFilteredData = this.state.filteredData.filter((item) =>
-          item.foodbankTags.includes(query)
+          item.originFarmContactName.toLowerCase().includes(parsedQuery)
         );
         break;
     }
 
-    this.setState(
-      { filteredData: multiFilteredData },
-      // Update tags with newly filtered data
-      this.populateAllTags
-    );
+    this.setState({ filteredData: multiFilteredData });
   };
 
   /** Returns additional search features that are collapsed at first glance */
   extraFiltersAccordion = () => {
-    const { locationQuery, filteredData } = this.state;
-
+    const {
+      produceNameQuery,
+      originFarmContactNameQuery,
+      filteredData,
+    } = this.state;
     return (
       <div>
         <Grid container spacing={3} alignItem="left">
           <Grid item xs={6}>
             <Autocomplete
-              id="location-search"
-              options={filteredData.map((data) => data.location)}
-              value={locationQuery}
-              onSelect={(e) => this.handleStringSearch("locationQuery", e)}
+              id="produce-search"
+              options={filteredData.map((data) => data.produceName)}
+              value={produceNameQuery}
+              onSelect={(e) => this.handleStringSearch("produceNameQuery", e)}
               fullWidth={true}
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  label="Food Bank Locations"
-                  placeholder="Type or Select a Location"
+                  label="Produce Names"
+                  placeholder="Type or Select a Produce Name"
                   variant="outlined"
-                  onChange={(e) => this.handleStringSearch("locationQuery", e)}
+                  onChange={(e) =>
+                    this.handleStringSearch("produceNameQuery", e)
+                  }
                   InputProps={{
                     ...params.InputProps,
                     startAdornment: (
@@ -330,10 +336,39 @@ class Surplus extends Component {
             />
           </Grid>
           <Grid item xs={6}>
-            {this.tagsAutocomplete()}
+            <Autocomplete
+              id="contact-search"
+              options={filteredData.map((data) => data.originFarmContactName)}
+              value={originFarmContactNameQuery}
+              onSelect={(e) =>
+                this.handleStringSearch("originFarmContactNameQuery", e)
+              }
+              fullWidth={true}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Farm Contact Names"
+                  placeholder="Type or Select a Farm Contact Name"
+                  variant="outlined"
+                  onChange={(e) =>
+                    this.handleStringSearch("originFarmContactNameQuery", e)
+                  }
+                  InputProps={{
+                    ...params.InputProps,
+                    startAdornment: (
+                      <>
+                        <InputAdornment position="start">
+                          <SearchIcon />
+                        </InputAdornment>
+                        {params.InputProps.startAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+            />
           </Grid>
         </Grid>
-        <Filters database="foodbanks"></Filters>
       </div>
     );
   };
@@ -342,7 +377,6 @@ class Surplus extends Component {
   filteringAccordion = () => {
     const { classes } = this.props;
     const { nameQuery, filteredData } = this.state;
-
     return (
       <div>
         <Accordion>
@@ -354,19 +388,19 @@ class Surplus extends Component {
             <Autocomplete
               id="nameQuery"
               options={[
-                ...new Set(filteredData.map((data) => data.foodbankName)),
+                ...new Set(filteredData.map((data) => data.originFarmName)),
               ]}
               value={nameQuery}
-              onSelect={(e) => this.handleStringSearch("nameQuery", e)}
+              onSelect={(e) => this.handleStringSearch("farmNameQuery", e)}
               fullWidth={true}
               renderInput={(params) => (
                 <TextField
                   {...params}
                   label="Foodbank Names"
-                  placeholder="Type or Select a Food Bank Name"
+                  placeholder="Type or Select a Farm Name"
                   variant="outlined"
-                  name="nameQuery"
-                  onChange={(e) => this.handleStringSearch("nameQuery", e)}
+                  name="farmNameQuery"
+                  onChange={(e) => this.handleStringSearch("farmNameQuery", e)}
                   InputProps={{
                     ...params.InputProps,
                     startAdornment: (
@@ -480,106 +514,109 @@ class Surplus extends Component {
     const { classes } = this.props;
     const { filteredData } = this.state;
 
-    return <div>
-       {this.state.surplusObjects.map((surplus) => (
-                <Grid item xs={12}>
-                  <Card
-                    className={classes.root}
-                    raised={surplus.surplusId === this.state.selectedCard}
-                    variant={
-                      surplus.surplusId === this.state.selectedCard
-                        ? "elevation"
-                        : "outlined"
-                    }
+    return (
+      <div>
+        <Grid container spacing={2} alignItem="center">
+          {this.state.filteredData.map((surplus) => (
+            <Grid item xs={12}>
+              <Card
+                className={classes.root}
+                raised={surplus.surplusId === this.state.selectedCard}
+                variant={
+                  surplus.surplusId === this.state.selectedCard
+                    ? "elevation"
+                    : "outlined"
+                }
+              >
+                <CardContent>
+                  <Typography variant="h5" component="h2">
+                    {surplus.totalQuantityAvailable} lbs of{" "}
+                    {surplus.produceName} from {surplus.originFarmName}
+                  </Typography>
+                  <Box
+                    display="flex"
+                    flexDirection="row"
+                    flexWrap="wrap"
+                    padding={0}
+                    margin={0}
                   >
-                    <CardContent>
-                      <Typography variant="h5" component="h2">
-                        {surplus.totalQuantityAvailable} lbs of{" "}
-                        {surplus.produceName} from {surplus.originFarmName}
-                      </Typography>
-                      <Box
-                        display="flex"
-                        flexDirection="row"
-                        flexWrap="wrap"
-                        padding={0}
-                        margin={0}
+                    <Box padding={3}>
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
                       >
-                        <Box padding={3}>
-                          <Typography
-                            className={classes.position}
-                            color="textSecondary"
-                          >
-                            Logistics:
-                          </Typography>
-                          <Typography variant="body2" component="p">
-                            Origin: {surplus.originFarmName}
-                            <br />
-                            Packing Type: {surplus.packagingType}
-                            <br />
-                            Available: {surplus.available ? "yes" : "no"}
-                          </Typography>
-                        </Box>
-                        <Box padding={3}>
-                          <Typography
-                            className={classes.position}
-                            color="textSecondary"
-                          >
-                            Details:
-                          </Typography>
-                          <Typography variant="body2" component="p">
-                            Type of Produce: {surplus.produceName}
-                            <br />
-                            Total Quantity Available (lbs):{" "}
-                            {surplus.totalQuantityAvailable}
-                            <br />
-                            Cost (USD / lb): {surplus.cost}
-                          </Typography>
-                        </Box>
-                      </Box>
-                    </CardContent>
-                    <CardActions>
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleViewOpen({ surplus })}
-                        >
-                          View
-                        </Button>
-                      )}
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleEditClick({ surplus })}
-                        >
-                          Edit
-                        </Button>
-                      )}
-                      {!this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleDelete({ surplus })}
-                        >
-                          Delete
-                        </Button>
-                      )}
-                      {this.props.inStepper && (
-                        <Button
-                          size="small"
-                          color="primary"
-                          onClick={() => this.handleSelect({ surplus })}
-                        >
-                          Select
-                        </Button>
-                      )}
-                    </CardActions>
-                  </Card>
-                </Grid>
-              ))}
+                        Logistics:
+                      </Typography>
+                      <Typography variant="body2" component="p">
+                        Origin: {surplus.originFarmName}
+                        <br />
+                        Packing Type: {surplus.packagingType}
+                        <br />
+                        Available: {surplus.available ? "yes" : "no"}
+                      </Typography>
+                    </Box>
+                    <Box padding={3}>
+                      <Typography
+                        className={classes.position}
+                        color="textSecondary"
+                      >
+                        Details:
+                      </Typography>
+                      <Typography variant="body2" component="p">
+                        Type of Produce: {surplus.produceName}
+                        <br />
+                        Total Quantity Available (lbs):{" "}
+                        {surplus.totalQuantityAvailable}
+                        <br />
+                        Cost (USD / lb): {surplus.cost}
+                      </Typography>
+                    </Box>
+                  </Box>
+                </CardContent>
+                <CardActions>
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleViewOpen({ surplus })}
+                    >
+                      View
+                    </Button>
+                  )}
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleEditClick({ surplus })}
+                    >
+                      Edit
+                    </Button>
+                  )}
+                  {!this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleDelete({ surplus })}
+                    >
+                      Delete
+                    </Button>
+                  )}
+                  {this.props.inStepper && (
+                    <Button
+                      size="small"
+                      color="primary"
+                      onClick={() => this.handleSelect({ surplus })}
+                    >
+                      Select
+                    </Button>
+                  )}
+                </CardActions>
+              </Card>
             </Grid>
-    </div>;
+          ))}
+        </Grid>
+      </div>
+    );
   };
 
   /**
@@ -872,7 +909,7 @@ class Surplus extends Component {
                 {this.filteringAccordion()}
               </Grid>
             </Grid>
-              {this.handleResultsRender()}
+            {this.handleResultsRender()}
           </Container>
 
           <Dialog


### PR DESCRIPTION
![React App (7)](https://user-images.githubusercontent.com/43034257/92090643-80c3c100-ed84-11ea-8fae-c3a4e1da971d.gif)

- commit 80d661a is purely copy-pasting from foodbanks.js 
- all commits after it are my specific Surplus-related modifications: 

  (aka if you preview those commits you can see the specific edits here)  
  (**for future, when making a reusable search, make it flexible enough to add these changes)

-- update field names and conditions for customized searches in simpleSearch cases, in multiple params of the Autocomplete search bars
-- get rid of tag/array field specific populating operations
-- reset all search states/queries in resetCards, including filteredData


- adding the three unique search bars
- updating simpleSearch to query from each search bar

future note (added to handoff doc too): 
for deals search, to search through contact names, make sure to populate all possible contact names by iterating over nested contact arrays and accessing contact names. similar to populateAllTags function