### PR TITLE
Update produce search: get rid of accordion and tag filtering skeleton

### DIFF
--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -137,7 +137,7 @@ class Filters extends Component {
             handleLocation={this.handleLocation}
             location={this.state.location}
             searching={true}
-            PlaceholderText="Type or Select a Location to find Nearby Farms"
+            PlaceholderText="Type or Select a Location to Search Nearby"
             TextFieldLabel="Custom Location"
           />
         </Grid>

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -223,6 +223,8 @@ class Foodbank extends Component {
       filteredData: [],
       nameQuery: "",
       locationQuery: "",
+      loadSizeQuery: 0,
+      fridgeSpaceQuery: 0,
       tagsQuery: [],
       allTags: [],
       // Aggregated tags used for options when editing a specific item
@@ -328,6 +330,64 @@ class Foodbank extends Component {
     }
   };
 
+  /** Filters for minimum load size and available refridgeration space */
+  capacityFilters = () => {
+    return (
+      <Grid container spacing={3} alignItem="left">
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
+            label="Fridge Space (Pallets)"
+            name="fridgeSpaceQuery"
+            type="number"
+            value={this.state.fridgeSpaceQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={() =>
+              this.simpleSearch("fridgeSpaceQuery", this.state.fridgeSpaceQuery)
+            }
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Fridge Space
+          </Button>
+        </Grid>
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
+            label="Load Size (Pallets)"
+            name="loadSizeQuery"
+            type="number"
+            value={this.state.loadSizeQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={() =>
+              this.simpleSearch("loadSizeQuery", this.state.loadSizeQuery)
+            }
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Load Size
+          </Button>
+        </Grid>
+      </Grid>
+    );
+  };
+
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
@@ -346,6 +406,16 @@ class Foodbank extends Component {
       case "tags-search":
         multiFilteredData = this.state.filteredData.filter((item) =>
           item.foodbankTags.includes(query)
+        );
+        break;
+      case "loadSizeQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.maxLoadSize) > query
+        );
+        break;
+      case "fridgeSpaceQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.refrigerationSpaceAvailable) > query
         );
         break;
     }
@@ -399,6 +469,7 @@ class Foodbank extends Component {
           </Grid>
         </Grid>
         <Filters database="foodbanks"></Filters>
+        {this.capacityFilters()}
       </div>
     );
   };
@@ -534,6 +605,8 @@ class Foodbank extends Component {
         filteredData: [...this.state.foodbanks],
         nameQuery: "",
         locationQuery: "",
+        loadSizeQuery: 0,
+        fridgeSpaceQuery: 0,
         tagsQuery: [],
       },
       this.populateAllTags

--- a/view/src/components/produce.js
+++ b/view/src/components/produce.js
@@ -290,15 +290,6 @@ class Produce extends Component {
 
     return (
       <div>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1a-content"
-            id="panel1a-header"
-          >
-            <Typography className={classes.heading}>Search by Name</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
             <Autocomplete
               id="produce-name-search"
               options={data.map((produce) => produce.name)}
@@ -325,21 +316,7 @@ class Produce extends Component {
                 />
               )}
             />
-          </AccordionDetails>
-        </Accordion>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2a-content"
-            id="panel2a-header"
-          >
-            <Typography className={classes.heading}>Filter by Tags</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            {/* TODO(fatimazali): Add tag filtering) */}
-            <Typography>Select tags to filter by:</Typography>
-          </AccordionDetails>
-        </Accordion>
+
       </div>
     );
   };

--- a/view/src/components/produce.js
+++ b/view/src/components/produce.js
@@ -290,33 +290,32 @@ class Produce extends Component {
 
     return (
       <div>
-            <Autocomplete
-              id="produce-name-search"
-              options={data.map((produce) => produce.name)}
-              value={value}
-              onSelect={this.handleSearch} // Receive the name from data element for value
-              fullWidth={true}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Produce Names"
-                  variant="outlined"
-                  onChange={this.handleSearch}
-                  InputProps={{
-                    ...params.InputProps,
-                    startAdornment: (
-                      <>
-                        <InputAdornment position="start">
-                          <SearchIcon />
-                        </InputAdornment>
-                        {params.InputProps.startAdornment}
-                      </>
-                    ),
-                  }}
-                />
-              )}
+        <Autocomplete
+          id="produce-name-search"
+          options={data.map((produce) => produce.name)}
+          value={value}
+          onSelect={this.handleSearch} // Receive the name from data element for value
+          fullWidth={true}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Produce Names"
+              variant="outlined"
+              onChange={this.handleSearch}
+              InputProps={{
+                ...params.InputProps,
+                startAdornment: (
+                  <>
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                    {params.InputProps.startAdornment}
+                  </>
+                ),
+              }}
             />
-
+          )}
+        />
       </div>
     );
   };


### PR DESCRIPTION
After discussing with the podmates, we realized there are currently no secondary features worth searching produce for. So, I reduced the produce search to only name searching. 

For now, I kept the usage of the search-filter-library, to avoid re-pasting the search functions that I've written and used. After the re-usable search component is created, its functions can be re-used here (specifically, string searching functions and simpleSearch). 

