### PR TITLE
Add minimum capacity filters to food bank

### DIFF
--- a/view/src/components/filters.js
+++ b/view/src/components/filters.js
@@ -137,7 +137,7 @@ class Filters extends Component {
             handleLocation={this.handleLocation}
             location={this.state.location}
             searching={true}
-            PlaceholderText="Type or Select a Location to find Nearby Farms"
+            PlaceholderText="Type or Select a Location to Search Nearby"
             TextFieldLabel="Custom Location"
           />
         </Grid>

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -223,6 +223,8 @@ class Foodbank extends Component {
       filteredData: [],
       nameQuery: "",
       locationQuery: "",
+      loadSizeQuery: 0,
+      fridgeSpaceQuery: 0,
       tagsQuery: [],
       allTags: [],
       // Aggregated tags used for options when editing a specific item
@@ -328,9 +330,41 @@ class Foodbank extends Component {
     }
   };
 
+  /** Filters for minimum load size and available refridgeration space */
+  capacityFilters = () => {
+    return (
+      <Grid container spacing={3} alignItem="left">
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
+            label="Load Size (Pallets)"
+            name="loadSizeQuery"
+            type="number"
+            value={this.state.loadSizeQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={(e) => this.handleStringSearch("loadSizeQuery", e)}
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Load Size
+          </Button>
+        </Grid>
+      </Grid>
+    );
+  };
+
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
+    console.log("query", query);
 
     switch (field) {
       case "nameQuery":
@@ -346,6 +380,11 @@ class Foodbank extends Component {
       case "tags-search":
         multiFilteredData = this.state.filteredData.filter((item) =>
           item.foodbankTags.includes(query)
+        );
+        break;
+      case "loadSizeQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.maxLoadSize) > query
         );
         break;
     }
@@ -447,7 +486,10 @@ class Foodbank extends Component {
               )}
             />
           </AccordionSummary>
-          <AccordionDetails>{this.extraFiltersAccordion()}</AccordionDetails>
+          <AccordionDetails>
+            {this.extraFiltersAccordion()}
+            {this.capacityFilters()}
+          </AccordionDetails>
           <Grid container alignItem="left">
             <Grid item xs={12}>
               <Box paddingLeft={2} paddingBottom={2}>

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -356,7 +356,7 @@ class Foodbank extends Component {
             size="medium"
             startIcon={<SearchIcon />}
           >
-            Filter by Min Refrigeration Space
+            Filter by Min Fridge Space
           </Button>
         </Grid>
         <Grid item xs={3}>
@@ -391,7 +391,6 @@ class Foodbank extends Component {
   /** Makes appropriate search by field and query of the data, updates filtered page states */
   simpleSearch = (field, query) => {
     var multiFilteredData = [];
-    console.log("query", query);
 
     switch (field) {
       case "nameQuery":

--- a/view/src/components/foodbanks.js
+++ b/view/src/components/foodbanks.js
@@ -337,6 +337,31 @@ class Foodbank extends Component {
         <Grid item xs={3}>
           <TextField
             variant="outlined"
+            label="Fridge Space (Pallets)"
+            name="fridgeSpaceQuery"
+            type="number"
+            value={this.state.fridgeSpaceQuery}
+            onChange={this.handleChange}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <Button
+            className={styles.searchButton}
+            onClick={() =>
+              this.simpleSearch("fridgeSpaceQuery", this.state.fridgeSpaceQuery)
+            }
+            variant="outlined"
+            color="primary"
+            type="number"
+            size="medium"
+            startIcon={<SearchIcon />}
+          >
+            Filter by Min Refrigeration Space
+          </Button>
+        </Grid>
+        <Grid item xs={3}>
+          <TextField
+            variant="outlined"
             label="Load Size (Pallets)"
             name="loadSizeQuery"
             type="number"
@@ -347,7 +372,9 @@ class Foodbank extends Component {
         <Grid item xs={3}>
           <Button
             className={styles.searchButton}
-            onClick={(e) => this.handleStringSearch("loadSizeQuery", e)}
+            onClick={() =>
+              this.simpleSearch("loadSizeQuery", this.state.loadSizeQuery)
+            }
             variant="outlined"
             color="primary"
             type="number"
@@ -385,6 +412,11 @@ class Foodbank extends Component {
       case "loadSizeQuery":
         multiFilteredData = this.state.filteredData.filter(
           (item) => parseInt(item.maxLoadSize) > query
+        );
+        break;
+      case "fridgeSpaceQuery":
+        multiFilteredData = this.state.filteredData.filter(
+          (item) => parseInt(item.refrigerationSpaceAvailable) > query
         );
         break;
     }
@@ -438,6 +470,7 @@ class Foodbank extends Component {
           </Grid>
         </Grid>
         <Filters database="foodbanks"></Filters>
+        {this.capacityFilters()}
       </div>
     );
   };
@@ -486,10 +519,7 @@ class Foodbank extends Component {
               )}
             />
           </AccordionSummary>
-          <AccordionDetails>
-            {this.extraFiltersAccordion()}
-            {this.capacityFilters()}
-          </AccordionDetails>
+          <AccordionDetails>{this.extraFiltersAccordion()}</AccordionDetails>
           <Grid container alignItem="left">
             <Grid item xs={12}>
               <Box paddingLeft={2} paddingBottom={2}>
@@ -576,6 +606,8 @@ class Foodbank extends Component {
         filteredData: [...this.state.foodbanks],
         nameQuery: "",
         locationQuery: "",
+        loadSizeQuery: 0,
+        fridgeSpaceQuery: 0,
         tagsQuery: [],
       },
       this.populateAllTags


### PR DESCRIPTION
![Screenshot 2020-09-03 at 2 40 52 AM](https://user-images.githubusercontent.com/43034257/92099084-efa61780-ed8e-11ea-9f01-66ea40f310eb.png)

- Users can enter a min load size or min available fridge space (both in pallets) and filter out food banks that don't have enough capacity for a surplus item

Any ideas on how to make the buttons/text for "refrigeration space" prettier are welcome--I was considering writing "fridge" to shorten it. Or other UI concerns